### PR TITLE
Issue #43 , auto focus of keyboard on login page, solved

### DIFF
--- a/lib/individual/health.dart
+++ b/lib/individual/health.dart
@@ -1,18 +1,15 @@
 import 'package:flutter/material.dart';
-import 'package:cura/shared/widgets/gradient_background.dart';
-import 'package:cura/main.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:searchfield/searchfield.dart';
-// import 'package:searchfield/searchfield.dart';
 
-class health extends StatefulWidget {
-  const health({Key? key}) : super(key: key);
+class HealthPage extends StatefulWidget {
+  const HealthPage({Key? key}) : super(key: key);
 
   @override
-  State<health> createState() => _healthState();
+  State<HealthPage> createState() => _HealthPageState();
 }
 
-class _healthState extends State<health> {
+class _HealthPageState extends State<HealthPage> {
   @override
   Widget build(BuildContext context) {
     return ScreenUtilInit(
@@ -215,20 +212,5 @@ class _healthState extends State<health> {
                     ),
               )
             );
-
-//import 'package:flutter/material.dart';
-
-//class HealthPage extends StatefulWidget {
-//  const HealthPage({super.key});
-
- // @override
- // State<HealthPage> createState() => _HealthPageState();
-//}
-
-//class _HealthPageState extends State<HealthPage> {
-//  @override
-//  Widget build(BuildContext context) {
-//   return Container();
-//
-//  }
-//}
+ }
+}

--- a/lib/startup_screens/login.dart
+++ b/lib/startup_screens/login.dart
@@ -20,8 +20,7 @@ class UserLogin extends StatefulWidget {
   const UserLogin({Key? key, required this.isPhoneLogin}) : super(key: key);
 
   @override
-  State<UserLogin> createState() =>
-      _UserLoginState(isPhoneVerification: isPhoneLogin);
+  State<UserLogin> createState() => _UserLoginState(isPhoneVerification: isPhoneLogin);
 }
 
 class _UserLoginState extends State<UserLogin> {
@@ -134,6 +133,7 @@ class _UserLoginState extends State<UserLogin> {
                                 ),
                                 child: MaterialButton(
                                   onPressed: () {
+                                    FocusManager.instance.primaryFocus?.unfocus();
                                     setState(() {
                                       isPhoneVerification = true;
                                     });
@@ -162,6 +162,7 @@ class _UserLoginState extends State<UserLogin> {
                                 ),
                                 child: MaterialButton(
                                   onPressed: () {
+                                    FocusManager.instance.primaryFocus?.unfocus();
                                     setState(() {
                                       isPhoneVerification = false;
                                     });


### PR DESCRIPTION
Resolves #43 
@RitwikSingh28 
I have removed the auto focus of keyboard on switching between phone and email sections in login page, hence now on switching, keyboard pops off and thus clicking on email field opens up email type keyboard layout.